### PR TITLE
Git's pre-merge-commit hook doesn't work (with core.hooksPath, at least)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,4 +2,4 @@ merge test
 
 make sure you run `git config --local core.hooksPath git-hooks`
 
-start:
+start: make eggs


### PR DESCRIPTION
note the conflict in the readme.md

1. Clone
```
git checkout feature/make-eggs
git checkout main
git merge feature/make-eggs
```

Note the "pre-commit hook" log

Notice also, no "pre-merge-commit" log appears